### PR TITLE
Included the SEED licence prereq, and some additional notes for Mac users for onboarding

### DIFF
--- a/_sidebar.md
+++ b/_sidebar.md
@@ -8,5 +8,5 @@
   * [Onboard](seed-onboarding-instructions-windows)
   * [Offboard](seed-offboarding-instructions-for-windows)
 * [Terminology](term-definitions)
-<!--* [Terms and Policies](terms-and-policies)-->
-* [Raise an incident support request](raise-an-incident-support-request)
+* [Terms and Policies](terms-and-policies)
+<!--* [Raise an incident support request](raise-an-incident-support-request)-->

--- a/common-issues-while-onboarding-using-macos.md
+++ b/common-issues-while-onboarding-using-macos.md
@@ -5,7 +5,7 @@
 
 <kbd>![profile-installation-failed](images/onboarding-for-macos/profile-installation-failed.png)</kbd>
 
-1. Ensure that you have received an email confirming that the required licence has been assigned to you. If yes, proceed to step 2.
+1. Ensure you received an email from us confirming the licence required for SEED onboarding has been assigned to you. If yes, proceed to step 2.
 2. Go to the **Apple** menu > **System Preferences** > **Profiles**.
 3. If **Management Profile** is already an existing profile, select it and remove it by clicking the minus icon at the lower-left corner.
 

--- a/common-issues-while-onboarding-using-macos.md
+++ b/common-issues-while-onboarding-using-macos.md
@@ -5,7 +5,7 @@
 
 <kbd>![profile-installation-failed](images/onboarding-for-macos/profile-installation-failed.png)</kbd>
 
-1. Ensure that you have received an email confirming that a SEED licence has been assigned to you. If yes, proceed to step 2.
+1. Ensure that you have received an email confirming that the required licence has been assigned to you. If yes, proceed to step 2.
 2. Go to the **Apple** menu > **System Preferences** > **Profiles**.
 3. If **Management Profile** is already an existing profile, select it and remove it by clicking the minus icon at the lower-left corner.
 

--- a/common-issues-while-onboarding-using-macos.md
+++ b/common-issues-while-onboarding-using-macos.md
@@ -3,10 +3,11 @@
 <details>
   <summary>1. What should I do if profile installation fails while installing the management profile?</summary>
 
-  <kbd>![profile-installation-failed](images/onboarding-for-macos/profile-installation-failed.png)</kbd>
+<kbd>![profile-installation-failed](images/onboarding-for-macos/profile-installation-failed.png)</kbd>
 
-    1. Go to the <b>Apple</b> menu > <b>System Preferences</b> > <b>Profiles</b>.
-    2. If <b>Management Profile</b> is already an existing profile, select it and remove by clicking the minus icon at the bottom left corner.
+1. Ensure that you have received an email confirming that a SEED licence has been assigned to you. If yes, proceed to step 2.
+2. Go to the **Apple** menu > **System Preferences** > **Profiles**.
+3. If **Management Profile** is already an existing profile, select it and remove it by clicking the minus icon at the lower-left corner.
 
 </details>
 

--- a/prerequisites-for-onboarding.md
+++ b/prerequisites-for-onboarding.md
@@ -10,7 +10,7 @@ Following are the prerequisites for onboarding to SEED:
 
 ?> If you are a public officer using a non-SE GSIB machine and does not have a TechPass account, [sign up and onboard in to TechPass](https://docs.developer.tech.gov.sg/docs/techpass-user-guide/#/onboard-public-officers-using-non-se-machines) first. If you are a vendor who does not have a TechPass account, [Create TechPass account](https://docs.developer.tech.gov.sg/docs/techpass-user-guide/#/onboard-vendors-to-techpass) first.
 
-3. Ensure you have received an email stating that the required licence has been assigned to proceed with the for onboarding.
+3. Ensure you have received an email stating that the required licence has been assigned to proceed with the onboarding.
 
 4. Depending on your device, [remove existing softwares on your macOS](seed-pre-onboarding-clean-up-instructions-for-macos) or [remove existing softwares on your Windows](seed-pre-onboarding-clean-up-instructions-for-windows).
 

--- a/prerequisites-for-onboarding.md
+++ b/prerequisites-for-onboarding.md
@@ -10,7 +10,7 @@ Following are the prerequisites for onboarding to SEED:
 
 ?> If you are a public officer using a non-SE GSIB machine and does not have a TechPass account, [sign up and onboard in to TechPass](https://docs.developer.tech.gov.sg/docs/techpass-user-guide/#/onboard-public-officers-using-non-se-machines) first. If you are a vendor who does not have a TechPass account, [Create TechPass account](https://docs.developer.tech.gov.sg/docs/techpass-user-guide/#/onboard-vendors-to-techpass) first.
 
-3. Ensure you have received an email stating that a SEED licence has been assigned to proceed with the for onboarding.
+3. Ensure you have received an email stating that the required licence has been assigned to proceed with the for onboarding.
 
 4. Depending on your device, [remove existing softwares on your macOS](seed-pre-onboarding-clean-up-instructions-for-macos) or [remove existing softwares on your Windows](seed-pre-onboarding-clean-up-instructions-for-windows).
 

--- a/prerequisites-for-onboarding.md
+++ b/prerequisites-for-onboarding.md
@@ -10,7 +10,9 @@ Following are the prerequisites for onboarding to SEED:
 
 ?> If you are a public officer using a non-SE GSIB machine and does not have a TechPass account, [sign up and onboard in to TechPass](https://docs.developer.tech.gov.sg/docs/techpass-user-guide/#/onboard-public-officers-using-non-se-machines) first. If you are a vendor who does not have a TechPass account, [Create TechPass account](https://docs.developer.tech.gov.sg/docs/techpass-user-guide/#/onboard-vendors-to-techpass) first.
 
-3. Depending on your device, [remove existing softwares on your macOS](seed-pre-onboarding-clean-up-instructions-for-macos) or [remove existing softwares on your Windows](seed-pre-onboarding-clean-up-instructions-for-windows).
+3. Ensure you have received an email stating that a SEED licence has been assigned to proceed with the for onboarding.
+
+4. Depending on your device, [remove existing softwares on your macOS](seed-pre-onboarding-clean-up-instructions-for-macos) or [remove existing softwares on your Windows](seed-pre-onboarding-clean-up-instructions-for-windows).
 
 
 **Related articles**

--- a/seed-onboarding-instructions-for-macos.md
+++ b/seed-onboarding-instructions-for-macos.md
@@ -3,8 +3,10 @@
 This sections explains how public officers and vendors can onboard to SEED using their macOS device. Before onboarding, take a look at the [prerequisites for SEED onboarding](prerequisites-for-onboarding).
 
 
-?>  Based on your Mac settings, you may be prompted to restart or reset your password while onboarding.
-For a smooth onboarding journey, it is important to link your Apple ID to this Mac device. Generate a recovery key and keep it safe in a place other than the Mac device that you are going to onboard to SEED.
+!>  
+  - Based on your Mac settings, you may be prompted to restart or reset your password while onboarding.
+  - For a smooth onboarding journey, it is important to link your Apple ID to this Mac device.
+  - Generate a recovery key and keep it safe in a place other than the Mac device that you are going to onboard to SEED.
 
 During this onboarding journey you will do the following:
 

--- a/seed-onboarding-instructions-for-macos.md
+++ b/seed-onboarding-instructions-for-macos.md
@@ -3,10 +3,8 @@
 This sections explains how public officers and vendors can onboard to SEED using their macOS device. Before onboarding, take a look at the [prerequisites for SEED onboarding](prerequisites-for-onboarding).
 
 
-!>  
-  - Based on your Mac settings, you may be prompted to restart or reset your password while onboarding.
-  - For a smooth onboarding journey, it is important to link your Apple ID to this Mac device.
-  - Generate a recovery key and keep it safe in a place other than the Mac device that you are going to onboard to SEED.
+!> Based on your Mac settings, you may be prompted to restart or reset your password while onboarding. For a smooth onboarding journey, it is important to link your Apple ID to this Mac device.
+
 
 During this onboarding journey you will do the following:
 

--- a/seed-onboarding-instructions-for-macos.md
+++ b/seed-onboarding-instructions-for-macos.md
@@ -4,7 +4,7 @@ This sections explains how public officers and vendors can onboard to SEED using
 
 
 ?>  Based on your Mac settings, you may be prompted to restart or reset your password while onboarding.
-
+For a smooth onboarding journey, it is important to link your Apple ID to this Mac device. Generate a recovery key and keep it safe in a place other than the Mac device that you are going to onboard to SEED.
 
 During this onboarding journey you will do the following:
 


### PR DESCRIPTION
Included the following:

1. Ensure that user has received an email about their SEED licence in the prereq.
2. some additional notes for Mac users for onboarding. 
3. Updated the first question in the Common issues while onboarding for Mac users


@Yi De if the SEED licence has an expiry date we can mention that. It will be useful to mention that info so that user will do the onboarding within that date.