### PR TITLE
Update how-to-clone-a-bitbucket-repository-over-ssh-with-cloudflare-a…

### DIFF
--- a/faqs/how-to-clone-a-bitbucket-repository-over-ssh-with-cloudflare-access.md
+++ b/faqs/how-to-clone-a-bitbucket-repository-over-ssh-with-cloudflare-access.md
@@ -47,15 +47,15 @@ $ git clone ssh://git@bitbucket-ssh.ship.gov.sg:7999/ship/ship-lambda-script.git
 
 1. When `cloudflared` prompts you to log in, log in with TechPass.
 
-![cloudflare-login-success](../images/cloudflare-login-success-bitbucket-1.png ':size=400')
+![cloudflare-login-success](../images/cloudflare-login-success-bitbucket-1.png ':size=300')
 
 1. Authenticate your login.
 
-![cloudflare-login-success](../images/cloudflare-login-success-bitbucket-2.png ':size=400')
+![cloudflare-login-success](../images/cloudflare-login-success-bitbucket-2.png ':size=300')
 
 1. If the authentication is successful, the following messages will be displayed.
 
-![cloudflare-login-success](../images/cloudflare-login-success-bitbucket-3.png ':size=400')
+![cloudflare-login-success](../images/cloudflare-login-success-bitbucket-3.png ':size=300')
 
 The token is saved in your `~/.cloudflared` directory, and the git clone command clones the code repository.
 
@@ -90,20 +90,19 @@ $ git clone ssh://git@bitbucket-ssh.ship.gov.sg:7999/ship/ship-lambda-script.git
 
 ```
 
-<!--> **Note**:
-> If you're copying the clone url from the GitLab Web Interface, change the GitLab hostname from `gitlab-in.ship.gov.sg` to `gitlab-in-ssh.ship.gov.sg`.-->
+
 
 1. When `cloudflared` prompts you to log in, log in with TechPass.
 
-![cloudflare-login-success](../images/cloudflare-login-success-bitbucket-1.png  ':size=400')
+![cloudflare-login-success](../images/cloudflare-login-success-bitbucket-1.png  ':size=300')
 
 1. Authenticate your login.
 
-![cloudflare-login-success](../images/cloudflare-login-success-bitbucket-2.png ':size=400')
+![cloudflare-login-success](../images/cloudflare-login-success-bitbucket-2.png ':size=300')
 
 1. If the authentication is successful, the following messages will be displayed.
 
-![cloudflare-login-success](../images/cloudflare-login-success-bitbucket-3.png ':size=400')
+![cloudflare-login-success](../images/cloudflare-login-success-bitbucket-3.png ':size=300')
 
 The token is saved in your `~/.cloudflared` directory, and the git clone command clones the code repository.
 <!-- tabs:end -->


### PR DESCRIPTION
Update how-to-clone-a-bitbucket-repository-over-ssh-with-cloudflare-access.md

removed note that was not needed.