### PR TITLE
Ventura faq

### DIFF
--- a/document-history.md
+++ b/document-history.md
@@ -4,6 +4,7 @@ This table shows the history of updates to the SEED documentation.
 
 | Date  | Article | Change |
 | ------------- |:-------------:|:-------------|
+| 07 November 2022 | [General FAQ](https://docs.developer.tech.gov.sg/docs/security-suite-for-engineering-endpoint-devices/faqs/seed-faq-general) | Included a query for Mac users upgrading to macOS 13(Ventura). |
 | 31 October 2022 | [Announcements](announcements) | Posted an announcement for GCC 1.0 users yet to onboard their internet device to SEED.|
 | 29 October 2022 | [Configuration of common Developer CLI tools with Cloudflare WARP](https://docs.developer.tech.gov.sg/docs/security-suite-for-engineering-endpoint-devices/faqs/configuration-of-common-developer-cli-tools-with-cloudflare-warp) | Updated the [Docker](https://docs.developer.tech.gov.sg/docs/security-suite-for-engineering-endpoint-devices/faqs/configuration-of-common-developer-cli-tools-with-cloudflare-warp?id=docker). |
 | 21 October 2022 | [Announcements](announcements) and [SEED status](seed-status) page | Updated announcements and status page for Cloudflare WARP issues. |

--- a/faqs/seed-faq-general.md
+++ b/faqs/seed-faq-general.md
@@ -91,8 +91,20 @@ This is a known issue with Microsoft Defender version 101.54.16. To resolve this
 
  Big Sur 11 is the minimum version needed for a successful onboarding. If your macOS is an earlier version, ensure to [upgrade it to a later macOS version](https://support.apple.com/downloads/macos).
 
+ <!--
  > **Note**:
  > When you upgrade the OS of your Mac device, the OpenSSH settings found in `/etc/ssh/sshd_config` file may be reset. Hence, before proceeding to upgrade the OS of your Mac device, back up the `sshd_config` file so that you can easily restore if it gets reset during the OS upgrade.
+ -->
+
+ </details><hr />
+
+ <details>
+   <summary style="font-size:20px;font-weight:bold">Can I upgrade my macOS to macOS 13 (Ventura)?</summary>
+
+  You can safely upgrade your macOS to macOS 13(Ventura). However, you can't onboard macOS 13(Ventura) to SEED.
+
+  If you have already onboarded your Mac device to SEED and now upgrading to macOS 13(Ventura), you will not be able to see the failed checks for your device when you log in to the [DEEP dashboard](https://dashboard.deep.tech.gov.sg/).
+
 
  </details><hr />
 


### PR DESCRIPTION
Included a query for Mac users upgrading to macOS 13(Ventura) and some related additional info.
removed the note for backup sshd_config as it is no longer needed.